### PR TITLE
vis.analyzers.indexers.metre --> vis.analyzers.indexers.meter

### DIFF
--- a/wrappers/indexers/duration_indexer.py
+++ b/wrappers/indexers/duration_indexer.py
@@ -25,7 +25,7 @@
 
 from music21 import converter
 from rodan.jobs.base import RodanTask
-from vis.analyzers.indexers.metre import DurationIndexer
+from vis.analyzers.indexers.meter import DurationIndexer
 
 import logging
 logger = logging.getLogger('rodan')

--- a/wrappers/indexers/measure_indexer.py
+++ b/wrappers/indexers/measure_indexer.py
@@ -25,7 +25,7 @@
 
 from music21 import converter
 from rodan.jobs.base import RodanTask
-from vis.analyzers.indexers.metre import MeasureIndexer
+from vis.analyzers.indexers.meter import MeasureIndexer
 
 import logging
 logger = logging.getLogger('rodan')

--- a/wrappers/indexers/notebeatstrength_indexer.py
+++ b/wrappers/indexers/notebeatstrength_indexer.py
@@ -25,7 +25,7 @@
 
 from music21 import converter
 from rodan.jobs.base import RodanTask
-from vis.analyzers.indexers.metre import NoteBeatStrengthIndexer
+from vis.analyzers.indexers.meter import NoteBeatStrengthIndexer
 
 import logging
 logger = logging.getLogger('rodan')


### PR DESCRIPTION
`vis.analyzers.indexers.metre` has been renamed to `vis.analyzers.indexers.meter` (in [this commit](https://github.com/ELVIS-Project/vis-framework/commit/356c16b88fae58d6707824ce61efc856b85825a5)).